### PR TITLE
Add Portuguese (pt-PT) translations

### DIFF
--- a/TRANSLATIONS_GUIDE.md
+++ b/TRANSLATIONS_GUIDE.md
@@ -95,9 +95,9 @@ Before calling a locale "done for this round":
 ## Scope tracker (May 2026)
 
 - **Fully aligned to this guide:** EN (canonical), UA (native sign-off).
-- **Voice-passed AI drafts, pending native review:** DE, PL, ES, FR, SW, NL, IT, RU, JA.
+- **Voice-passed AI drafts, pending native review:** DE, PL, ES, FR, SW, NL, IT, RU, JA, PT (pt-PT — chrome + all 42 cards, added on its own branch).
 - **Tag/chrome touched only, cards untouched:** EL, TR, DK, NO, LV, RO.
 - **Needs full pass (still partly English fallback):** AR.
-- **Deferred until a later session:** PT-BR (Brazil ~1% traffic, currently English fallback).
+- **Deferred until a later session:** PT-BR (Brazil) — we shipped pt-PT (Portugal); a Brazilian variant could follow if traffic warrants.
 - **Out of scope, deferred:** team list (`About.tsx` `teamMembers` array), refreshing 2022-era card framing.
 - **Out of scope permanently:** widget page (discontinued), share / social copy (discontinued), About page localisation (English-only by design).

--- a/TRANSLATIONS_REVIEW.md
+++ b/TRANSLATIONS_REVIEW.md
@@ -248,3 +248,22 @@ Chrome `pl.ts` fixes (real bugs, not just voice):
 - Share / social copy (discontinued)
 - 12 other non-primary locales (RU, NL, JA, EL, AR, IT, TR, DK, LV, NO, RO, SW) — keep their tag fixes from this pass; full donation review deferred.
 - Code-level `# TODO: Remove this org` markers in donations #41, #45, #49 (also `#13` and #41/#45/#49 are `hidden: yes`). Not touched.
+
+---
+
+## New locale: Portuguese (pt-PT) — added this pass
+
+European Portuguese, informal *tu*, voice per `TRANSLATIONS_GUIDE.md`. **Entirely AI-assisted — no native pass yet. Needs a native PT reviewer before it is treated as final.** Shipped on its own branch (`add-portuguese`) / PR, separate from the main translations pass (#58).
+
+What was added:
+- **Registration** in `core/texts/index.ts`: `import pt`, added to `byLang`, `flagsMap['pt'] = '🇵🇹'`. Not RTL.
+- **Chrome** `core/texts/pt.ts`: meta, buttons, hero, tags, footer + goals, filter, payment methods, browseAll, legal popup translated. The About / verify / widget blocks are kept in **English** (out-of-scope per guide) — they *must* be present because `TextKeys` is the intersection of all locales' keys (`core/texts/index.ts:72`), so every locale carries the full key set; same approach as `de.ts`.
+- **Cards**: `pt.yml` for all 42 non-hidden orgs (description only; titles left as the orgs' original names — none have an established PT identity). Hidden orgs (#3, #4, #6, #13, #32, #35, #37, #38, #41, #45, #47, #49) not touched.
+
+Voice choices a native reviewer should sanity-check:
+- Tags: `Refugees → Ajuda a refugiados`, `Non-combat → Apoio não-combatente`, `filterTo → Causa`.
+- Inclusivity: PT has no clean inclusive marker, so neutral nouns where natural (`pessoas deslocadas`, `quem defende o país`, `quem precisa`). Generic masculine kept for profession words (`voluntários`, `veteranos`) — flag if the project wants these reframed, as was done for ES/IT.
+- `goal1` uses *resistir à invasão* (resist), not a "based on" calque.
+- Place names: `Kyiv`, `Kharkiv`, `Dnipro`, `Donbas` (Ukraine-aligned spellings).
+- PT-PT vocabulary used over PT-BR: `Partilhar` (not Compartilhar), `ligação` (not link), `connosco`, `ótica`, `eletrónica`.
+- `spreadTheWorld` left as the English "Spread the word" (matches `de.ts`; appears to be discontinued share copy).

--- a/donations/1/pt.yml
+++ b/donations/1/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A primeira organização de beneficência ucraniana autorizada a adquirir material militar, incluindo armamento, para as Forças Armadas. Fornece equipamento, tecnologia e formação, e gere centros de treino militar que reforçam a capacidade de defesa da Ucrânia.

--- a/donations/10/pt.yml
+++ b/donations/10/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Os Hospitallers são um batalhão médico de voluntários cujo lema é «Por cada vida». Os seus paramédicos atuam na linha da frente e nas suas imediações para evacuar feridos, prestar cuidados de emergência e reforçar a capacidade médica tática em toda a Ucrânia.

--- a/donations/11/pt.yml
+++ b/donations/11/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A primeira empresa médica militar privada da Ucrânia. O PDMSh é uma formação voluntária de profissionais de saúde integrada oficialmente nas Forças de Defesa, que assegura evacuação e tratamento médico em zonas de combate. Já tratou mais de 110 000 pessoas desde 2014.

--- a/donations/12/pt.yml
+++ b/donations/12/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Organização não-governamental ucraniana que fornece equipamento militar, tecnologia e assistência médica aos soldados ucranianos na linha da frente. Participa também no tratamento e na recuperação de soldados feridos e coordena o trabalho de profissionais de saúde: médicos na frente, cirurgiões, voluntários em unidades de saúde e farmacêuticos.

--- a/donations/14/pt.yml
+++ b/donations/14/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Organização ucraniana de voluntárias, surgida em 2014 com o início da guerra russo-ucraniana, que começou a sua atividade com formação pré-médica em massa para mulheres, combinada com preparação psicológica e psiquiátrica. Desde 2014, mais de 40 000 mulheres em toda a Ucrânia passaram pela sua formação.

--- a/donations/15/pt.yml
+++ b/donations/15/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A Lifeline Ukraine é uma linha de apoio nacional e profissional para prevenção do suicídio e saúde mental, em funcionamento 24 horas por dia, sete dias por semana. A Ucrânia perde demasiados veteranos por suicídio, um problema que é preciso enfrentar. Perante o ataque russo, apoia quem precisa agora.

--- a/donations/16/pt.yml
+++ b/donations/16/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A iniciativa cidadã Army SOS coordena voluntários que financiam e entregam material aos soldados ucranianos. A equipa adquire munições, equipamento de proteção, comunicações e meios de reconhecimento, fardamento e alimentação, e entrega os bens diretamente nas posições das unidades.

--- a/donations/17/pt.yml
+++ b/donations/17/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Esta organização de beneficência fornece a pessoas idosas de toda a Ucrânia mantimentos e medicamentos, organiza eventos educativos e de lazer e ajuda na procura de emprego. Chegou mesmo a criar uma agência de modelos para idosos.

--- a/donations/18/pt.yml
+++ b/donations/18/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Esforço global e descentralizado para ajudar os ucranianos e outros povos a lidar com a crise humanitária e com as consequências da brutal invasão da Federação Russa.

--- a/donations/19/pt.yml
+++ b/donations/19/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A Hromadske International reúne jornalismo de qualidade, novas ferramentas de media e análise objetiva num só lugar. É um projeto dinâmico, fundado por uma equipa singular de jornalistas ucranianos e estrangeiros.

--- a/donations/2/pt.yml
+++ b/donations/2/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Uma das maiores fundações de beneficência da Ucrânia, no apoio tanto aos militares como à população civil. Equipa quem defende o país com drones, comunicações, ótica, transporte e material médico, e presta ajuda humanitária — desminagem, cuidados de saúde, abrigos em escolas e habitação modular em comunidades libertadas.

--- a/donations/20/pt.yml
+++ b/donations/20/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Esta organização de beneficência cuida de pessoas idosas que vivem sozinhas e apoia os lares estatais. Defende também um melhor tratamento das pessoas idosas por parte do Estado, incluindo o acesso facilitado à educação para maiores de 60 anos.

--- a/donations/21/pt.yml
+++ b/donations/21/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Cria projetos de jornalismo de dados e trabalha nos géneros jornalísticos tradicionais com um olhar ucraniano sobre o mundo.

--- a/donations/22/pt.yml
+++ b/donations/22/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  O principal meio de comunicação independente em língua inglesa da Ucrânia, com cobertura e análise diárias da guerra e dos assuntos ucranianos.

--- a/donations/23/pt.yml
+++ b/donations/23/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A organização promove a doação de sangue regular, consciente e gratuita. Nos últimos seis anos, incentivou a doação de sangue mais de 5 000 vezes.

--- a/donations/24/pt.yml
+++ b/donations/24/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A Tabletochki é uma fundação ucraniana dedicada a crianças com cancro. Adquire medicamentos e equipamento médico, organiza tratamento no estrangeiro quando necessário e apoia as famílias através de acompanhamento prolongado e de parcerias com hospitais.

--- a/donations/25/pt.yml
+++ b/donations/25/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A Razom é uma organização internacional sem fins lucrativos com escritórios nos Estados Unidos e na Ucrânia. Presta ajuda médica e humanitária, forma socorristas e profissionais de saúde e defende o futuro democrático da Ucrânia através de programas de entrega de ajuda, educação e ação cívica.

--- a/donations/26/pt.yml
+++ b/donations/26/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Iniciativa de beneficência dedicada às questões da velhice na Ucrânia. Ajuda idosos que vivem sozinhos, fornecendo-lhes mantimentos e produtos de higiene.

--- a/donations/27/pt.yml
+++ b/donations/27/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Plataforma ucraniana de financiamento coletivo militar e civil, com várias iniciativas. Responde a pedidos oficiais e entrega equipamento crítico aos militares: dispositivos de alta tecnologia, modificação de armamento, ótica, equipamento de comunicação e munições. Coordena também o trabalho de voluntários para prestar a ajuda médica necessária e apoiar o tratamento e a reabilitação de feridos.

--- a/donations/28/pt.yml
+++ b/donations/28/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Organização sem fins lucrativos sediada nos EUA que apoia a Ucrânia através de quatro programas: equipamento tático, ajuda médica a mais de 260 hospitais, apoio humanitário e sensibilização. Desde 2014, distribuiu mais de 82 000 kits de primeiros socorros e forneceu veículos, geradores e mantimentos à população civil.

--- a/donations/29/pt.yml
+++ b/donations/29/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Organização sem fins lucrativos dedicada a prestar ajuda ao povo ucraniano, em defesa dos seus direitos fundamentais, e à reabilitação médica de soldados ucranianos.

--- a/donations/30/pt.yml
+++ b/donations/30/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Organização não-governamental que ajuda a encontrar abrigo para pessoas deslocadas internamente, evacua pessoas da zona de conflito, recolhe e distribui ajuda humanitária a deslocados em Kyiv, leva ajuda humanitária a localidades na linha da frente e presta primeiros socorros psicológicos.

--- a/donations/31/pt.yml
+++ b/donations/31/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A Blue/Yellow foi fundada na Lituânia, mas tem uma rede internacional consolidada. Desde 2014, já prestou quase 1 milhão de dólares em ajuda humanitária e equipamento militar em apoio às Forças Armadas da Ucrânia e à população civil da região do Donbas.

--- a/donations/33/pt.yml
+++ b/donations/33/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A Save the Children destina os donativos ao seu fundo de resposta à crise na Ucrânia, para ajudar crianças e famílias com alimentação, água, kits de higiene, apoio psicossocial e assistência financeira na Ucrânia e na região.

--- a/donations/34/pt.yml
+++ b/donations/34/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  O principal objetivo do Centro de Coordenação SaveUkraineNow é coordenar, analisar, reunir e enviar todo o tipo de ajuda para os locais em situação de maior necessidade.

--- a/donations/36/pt.yml
+++ b/donations/36/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Importante organização sem fins lucrativos sediada nos EUA que já ajudou mais de 13 milhões de ucranianos desde 2022. Atua em quatro eixos — Curar, Construir, Capacitar e Defender — prestando ajuda médica, reparação de infraestruturas, apoio psicossocial e ação política.

--- a/donations/39/pt.yml
+++ b/donations/39/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Objetivos: desenvolver e divulgar recursos de autoajuda psicoeducativos; formar profissionais de saúde mental nos vários níveis de cuidados; e tornar acessíveis os serviços de saúde mental aos civis que sofreram a experiência traumática da guerra.

--- a/donations/40/pt.yml
+++ b/donations/40/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Este movimento nasceu de uma campanha que angariou 2 milhões de dólares para obter o medicamento mais caro do mundo para um menino ucraniano com atrofia muscular espinhal (AME). Hoje angaria fundos para o tratamento de outras crianças ucranianas com AME.

--- a/donations/42/pt.yml
+++ b/donations/42/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Para ajudar os civis ucranianos na sua luta corajosa pela independência e pela liberdade, o UACC (Conselho Coordenador Ucraniano-Americano) reagiu depressa, obtendo uma licença especial para artigos regulados de grau militar.

--- a/donations/43/pt.yml
+++ b/donations/43/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Centro de reabilitação emocional e psicológica para crianças da guerra.

--- a/donations/44/pt.yml
+++ b/donations/44/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Um dos maiores meios de comunicação independentes da Ucrânia. Dedica-se habitualmente ao jornalismo de investigação, promove a literacia mediática e combate a corrupção. Hoje cobre o ataque da Rússia à Ucrânia.

--- a/donations/46/pt.yml
+++ b/donations/46/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Presta ajuda humanitária e serviços de logística a abrigos e centros regionais: alimentação, produtos de higiene, roupa, combustível e veículos.

--- a/donations/48/pt.yml
+++ b/donations/48/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Fornece alimentação, roupa, produtos de higiene e medicamentos. Presta cuidados de saúde, tratamento e apoio psicológico a crianças e mulheres afetadas pela guerra.

--- a/donations/5/pt.yml
+++ b/donations/5/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  O fundo de beneficência da comunidade tecnológica ucraniana, que dá às forças de defesa uma vantagem tecnológica. A KOLO fornece drones, sistemas de guerra eletrónica, equipamento de comunicação, ótica térmica e veículos robóticos para a linha da frente.

--- a/donations/50/pt.yml
+++ b/donations/50/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Ajuda famílias com bebés até aos 3 anos e mulheres grávidas a sobreviver na cidade de Kharkiv e na região sob bombardeamento, a alimentar os filhos e a sair da cidade.

--- a/donations/51/pt.yml
+++ b/donations/51/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Fornece todos os dias jantares quentes a milhares de pessoas necessitadas na cidade de Dnipro.

--- a/donations/52/pt.yml
+++ b/donations/52/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Fundo de beneficência oficial de apoio à 3.ª Brigada de Assalto Independente da Ucrânia. Fornece às unidades na linha da frente equipamento, veículos e material essencial, e apoia os soldados feridos através de programas associados de patronato, reabilitação e bem-estar.

--- a/donations/53/pt.yml
+++ b/donations/53/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A UNITED24 é a plataforma oficial de angariação do Presidente da Ucrânia, lançada em maio de 2022 para unir o apoio global à Ucrânia. Quem doa escolhe uma área — defesa, desminagem, ajuda médica, reconstrução ou educação — e os fundos ficam em contas próprias do Banco Nacional da Ucrânia, com prestação pública de contas.

--- a/donations/54/pt.yml
+++ b/donations/54/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A Leleka Foundation é uma organização sem fins lucrativos 501(c)(3) sediada nos EUA que apoia médicos na linha da frente na Ucrânia desde 2014. Fornece mochilas médicas táticas, torniquetes, veículos de evacuação e equipamento e formação afins; desde fevereiro de 2022, angariou mais de 13 milhões de dólares para ajuda médica que salva vidas a quem defende o país.

--- a/donations/7/pt.yml
+++ b/donations/7/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  A maior fundação ucraniana dedicada ao apoio psicológico a crianças afetadas pela guerra. Mantém centros por toda a Ucrânia com arteterapia, campos de férias, grupos de apoio e uma linha de ajuda nacional, e já chegou a mais de 145 000 crianças e pais desde a invasão em larga escala.

--- a/donations/8/pt.yml
+++ b/donations/8/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Conta oficial de angariação criada pelo Banco Nacional da Ucrânia para apoiar as Forças Armadas da Ucrânia. Os donativos reforçam a capacidade de defesa através de armamento, equipamento, alimentação, medicamentos e outros bens essenciais para os militares.

--- a/donations/9/pt.yml
+++ b/donations/9/pt.yml
@@ -1,0 +1,3 @@
+# AI-assisted draft (European Portuguese), pending native review
+description: >
+  Para encaminhar fundos humanitários para os ucranianos afetados pela guerra, o Banco Nacional da Ucrânia abriu uma conta direta que reúne donativos para necessidades sociais em tempo de guerra.


### PR DESCRIPTION
Adds **Portuguese (pt-PT)** donation translations and wires in the new locale.

- **42 `pt.yml` card files** — every non-hidden org. Description only; titles keep the orgs' original names (none have an established Portuguese identity). Hidden orgs untouched.
- **Submodule bump** to pull in the `pt` locale (site-core#21).
- `TRANSLATIONS_REVIEW.md` logs the new locale; `TRANSLATIONS_GUIDE.md` scope tracker updated.

Verified: `tsc --noEmit` clean and `next build && next export` emits `/pt` with Portuguese chrome + cards rendering and English fallback intact.

⚠️ **AI-assisted drafts — pending native PT review.** Voice notes for the reviewer are in `TRANSLATIONS_REVIEW.md`.

**Depends on site-core#21** (merge that first). Base is `translations-pass-2026-05` to stay separate from #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
